### PR TITLE
Add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"scripts": {
 		"test:unit": "vue-cli-service test:unit",
+		"test:coverage": "vue-cli-service test:unit --coverage",
 		"lint": "vue-cli-service lint"
 	},
 	"devDependencies": {


### PR DESCRIPTION
I've added a script to launch test coverage.
It's a good tool to see the pertinence of unit testing.

![image](https://user-images.githubusercontent.com/981841/197360611-25b1483c-ba62-4ba8-aa3c-a0ac258d4a4b.png)

I think the result could be improved.
Could you have a look on uncovered lines in `icon.js` to see if we could had tests to cover it?